### PR TITLE
Revert "Change key region to Ireland"

### DIFF
--- a/src/features/fixtures/before_fixtures.py
+++ b/src/features/fixtures/before_fixtures.py
@@ -660,9 +660,7 @@ def claimant_api_setup(context):
     context.execute_steps(
         f"given The claimant API 'business' region is set to 'Ireland'"
     )
-    context.execute_steps(
-        f"given The claimant API 'storage' region is set to 'Ireland'"
-    )
+    context.execute_steps(f"given The claimant API 'storage' region is set to 'London'")
     context.execute_steps(f"given The nino salt has been retrieved")
 
 


### PR DESCRIPTION
Reverts dwp/dataworks-behavioural-framework#34.

Need to revert temporarily to allow ucfs-claimant additional outputs to be applied to the QA environment.