### PR TITLE
Fix closure date to have date value in Kafka file, variable wasn't in scope. Incl. other fixes

### DIFF
--- a/src/features/steps/ucfs-claimant-api.py
+++ b/src/features/steps/ucfs-claimant-api.py
@@ -62,7 +62,7 @@ def step_impl(context, expected_value):
     assert context.claimant_api_response is not None, f"Response body was empty"
 
     response = context.claimant_api_response
-
+    console_printer.print_info(f"Claimant API Response: {context.claimant_api_response}")
     try:
         take_home_pay_enc = base64.urlsafe_b64decode(
             response["assessmentPeriod"][0]["amount"]["takeHomePay"]
@@ -633,21 +633,12 @@ def step_impl(context, data_file_name):
     try:
         actual_assessment_periods = response["assessmentPeriod"]
         console_printer.print_info(f"assessment period {response['assessmentPeriod']}")
-        take_home_pay_enc = base64.urlsafe_b64decode(
-            response["assessmentPeriod"][0]["amount"]["takeHomePay"]
-        )
-        cipher_text_blob = base64.urlsafe_b64decode(
-            response["assessmentPeriod"][0]["amount"]["cipherTextBlob"]
-        )
     except Exception as ex:
         console_printer.print_error_text(
             f"Could not retrieve assessment periods from claimant API response of '{response}' and error of '{ex}'"
         )
         raise ex
 
-    console_printer.print_info(
-        f"Successfully retrieved cipher text of '{cipher_text_blob}' and take home pay of '{take_home_pay_enc}'"
-    )
     nonce_size = 12
     console_printer.print_info(
         f"Successfully retrieved '{len(actual_assessment_periods)}' actual assessment periods"

--- a/src/features/ucfs-claimant-api.feature
+++ b/src/features/ucfs-claimant-api.feature
@@ -78,8 +78,9 @@ Feature: UCFS Claimant API
     When I query for the first claimant from claimant API 'v2' with the parameters file of '<parameters-file>'
     Then The assessment periods are correctly returned using data file of '<output-file>'
     Examples:
-    | data-file                                      |  parameters-file                                 |  output-file                                                |
-    | passported_benefits_regression_scenario_10.yml |  passported_benefits_regression_scenario_10.yml  |  passported_benefits_regression_scenario_10_last_month.yml  |
+    | data-file                                      |  parameters-file                                 |  output-file                                                 |
+    | passported_benefits_regression_scenario_10.yml |  passported_benefits_regression_scenario_10.yml  |  passported_benefits_regression_scenario_10_last_month.yml   |
+    | passported_benefits_regression_scenario_8.yml  |  passported_benefits_regression_scenario_8.yml   |  passported_benefits_regression_scenario_8_middle_month.yml  |
 
   Scenario Outline: Passported benefits regression scenarios (suspended)
     Given UCFS send claimant API kafka messages with input file of 'valid_file_input.json' and data file of '<data-file>'

--- a/src/helpers/claimant_api_data_generator.py
+++ b/src/helpers/claimant_api_data_generator.py
@@ -448,11 +448,12 @@ def _generate_contract_and_statement_db_objects(
 
     payment_day_of_month = 23
 
+    closed_date = None
     if "contract_closed_date" in item:
         closed_date = item["contract_closed_date"]
+        console_printer.print_info(f"closed_date: '{closed_date}'")
     elif (
-        "contract_closed_date_days_offset" in item
-        or "contract_closed_date_months_offset" in item
+            "contract_closed_date_days_offset" in item or "contract_closed_date_month_offset" in item
     ):
         date_offset = (
             item["contract_closed_date_days_offset"]
@@ -460,8 +461,8 @@ def _generate_contract_and_statement_db_objects(
             else None
         )
         month_offset = (
-            item["contract_closed_date_months_offset"]
-            if "contract_closed_date_months_offset" in item
+            item["contract_closed_date_month_offset"]
+            if "contract_closed_date_month_offset" in item
             else None
         )
         closed_date = generate_dynamic_date(
@@ -470,6 +471,7 @@ def _generate_contract_and_statement_db_objects(
         console_printer.print_info(f"closed_date: '{closed_date}'")
     else:
         closed_date = None
+
 
     # Note: Date offsets are simply to make data more natural, nothing known to depend on them
     contract = {

--- a/src/helpers/claimant_api_data_generator.py
+++ b/src/helpers/claimant_api_data_generator.py
@@ -520,7 +520,7 @@ def _generate_contract_and_statement_db_objects(
         suspension_date = generate_dynamic_date(
             todays_date, date_offset, month_offset
         ).strftime("%Y%m%d")
-        contract["claimSuspension"] = {"suspensionDate": suspension_date}
+        contract["claimSuspension"] = {"suspensionDate": int(suspension_date)}
         console_printer.print_info(f"suspension_date: '{suspension_date}'")
     elif unique_suffix % 10 == 0:
         contract["claimSuspension"] = {"suspensionDate": None}


### PR DESCRIPTION
Remove unnecessary base64 decoding of THP - Not used. It is decoded per assessment period in the for loop.
Include test scenario for query parameter check for scenario 8.
Signed-off-by: Connor Avery <ConnorAvery@digital.uc.dwp.gov.uk>